### PR TITLE
Preserve Composer cache directory in MagentoComposerApplication

### DIFF
--- a/src/HomeEnvironmentChanger.php
+++ b/src/HomeEnvironmentChanger.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * @author Tom Klingenberg <https://github.com/ktomk>
+ *
+ * Parts of this file were part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * @license MIT
+ * @see \Composer\Factory::getHomeDir()
+ */
+
+namespace Magento\Composer;
+
+use RuntimeException;
+
+/**
+ * Class ChangedHomeEnvironment
+ *
+ * Magento changes the Composer home envirnment. This class encapsulates such a change
+ * and it's state.
+ *
+ * @package Magento\Composer
+ */
+class HomeEnvironmentChanger
+{
+    /**
+     * Path
+     *
+     * @var string
+     */
+    private $newComposerHomePath;
+
+    /**
+     * ChangedHomeEnvironment static constructor.
+     *
+     * @param string $newComposerHomePath
+     * @return HomeEnvironmentChanger
+     */
+    public static function create($newComposerHomePath)
+    {
+        if (!is_dir($newComposerHomePath) || !is_writeable($newComposerHomePath))
+        {
+            throw new RuntimeException(
+                sprintf(
+                    'Path for composer home is not a directory or not writeable: %s'
+                    , json_encode($newComposerHomePath)
+                )
+            );
+        }
+
+        $changer = new static($newComposerHomePath);
+
+        return $changer;
+    }
+
+    /**
+     * ChangedHomeEnvironment private constructor.
+     *
+     * @param string $newComposerHomePath
+     */
+    private function __construct($newComposerHomePath)
+    {
+        $this->newComposerHomePath = $newComposerHomePath;
+    }
+
+    /**
+     * Change composer home by preserving cache and auth.
+     *
+     * @return HomeEnvironmentChanger
+     * f
+     */
+    public function change()
+    {
+        $current = rtrim($this->getComposerHomeDir(), '/');
+        $target = rtrim($this->newComposerHomePath, '/');
+
+        // nothing to change - exit early
+        if ($current === $target) {
+            return $this;
+        }
+
+        $environment = [];
+
+        // new composer home
+        $environment['COMPOSER_HOME'] = $target;
+
+        // do not degrade cache
+        $cache = getenv('COMPOSER_CACHE');
+        if (!$cache) {
+            $environment['COMPOSER_CACHE'] = $current . '/cache';
+        }
+
+        $this->putEnvironment($environment);
+
+        return $this;
+    }
+
+    /**
+     * Put zero or more variables into the environment
+     *
+     *
+     * @param array $environment
+     * @return void
+     */
+    private function putEnvironment(/* @codingStandardsIgnoreStart */
+        array $environment
+        /* @codingStandardsIgnoreEnd */
+    )
+    {
+        foreach ($environment as $name => $value) {
+            if (putenv("$name=$value")) {
+                continue;
+            }
+
+            throw new RuntimeException(
+                sprintf("Failed to set environment %s variable (via putenv()) to %s")
+            );
+        }
+    }
+
+    /**
+     * Detect the Composer Home Directory as composer does it
+     *
+     * @see \Composer\Factory::getHomeDir()
+     *
+     * @return string
+     */
+    private function getComposerHomeDir()
+    {
+        $home = getenv('COMPOSER_HOME');
+        if (!$home) {
+            if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
+                if (!getenv('APPDATA')) {
+                    throw new \RuntimeException('The APPDATA or COMPOSER_HOME environment variable must be set for composer to run correctly');
+                }
+                $home = strtr(getenv('APPDATA'), '\\', '/') . '/Composer';
+            } else {
+                if (!getenv('HOME')) {
+                    throw new \RuntimeException('The HOME or COMPOSER_HOME environment variable must be set for composer to run correctly');
+                }
+                $home = rtrim(getenv('HOME'), '/') . '/.composer';
+            }
+        }
+
+        return $home;
+    }
+}

--- a/src/MagentoComposerApplication.php
+++ b/src/MagentoComposerApplication.php
@@ -23,9 +23,9 @@ class MagentoComposerApplication
     const COMPOSER_WORKING_DIR = '--working-dir';
 
     /**
-     * Path to Composer home directory
+     * Composer home directory changer
      *
-     * @var string
+     * @var HomeEnvironmentChanger
      */
     private $composerHome;
 
@@ -75,9 +75,7 @@ class MagentoComposerApplication
         $this->consoleOutput = $consoleOutput ? $consoleOutput : new BufferedOutput();
 
         $this->composerJson = $pathToComposerJson;
-        $this->composerHome = $pathToComposerHome;
-
-        putenv('COMPOSER_HOME=' . $pathToComposerHome);
+        $this->composerHome = HomeEnvironmentChanger::create($pathToComposerHome)->change();
 
         $this->consoleApplication->setAutoExit(false);
     }

--- a/tests/Composer/HomeEnvironmentChangerTest.php
+++ b/tests/Composer/HomeEnvironmentChangerTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * @author Tom Klingenberg <https://github.com/ktomk>
+ */
+
+namespace Magento\Composer;
+
+/**
+ * Class HomeEnvironmentChangerTest
+ *
+ * @package Magento\Composer
+ * @covers Magento\Composer\HomeEnvironmentChanger
+ */
+class HomeEnvironmentChangerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Path to (temporary) test directory
+     *
+     * @var string
+     */
+    private $testDir;
+
+    protected function setUp()
+    {
+        $tmpDir = sys_get_temp_dir();
+        if (!$tmpDir) {
+            throw new \RuntimeException('Unable to obtain temporary directory');
+        }
+
+        $testDir = $tmpDir . '/homeenv-test/new_home';
+        if (!is_dir($testDir) && !mkdir($testDir, 0777, true)) {
+            throw new \RuntimeException('Unable to create test directory');
+        }
+
+        $this->testDir = $testDir;
+    }
+
+    protected function tearDown()
+    {
+        rmdir($this->testDir) && rmdir(dirname($this->testDir));
+    }
+
+    /**
+     * Test
+     *
+     * @test that composer home change operation does not change the path to the composer cache.
+     *
+     * this allows to keep all cache entries.
+     *
+     * @return void
+     */
+    public function changeRetainsCache()
+    {
+        $newHome = $this->testDir;
+
+        $this->assertFalse(getenv('COMPOSER_CACHE'));
+        $this->assertFalse(getenv('COMPOSER_HOME'));
+        $this->assertNotFalse($homeDir = getenv('HOME'));
+
+        $oldHome = rtrim($homeDir, '/') . '/.composer';
+
+        // changing it to the current directory should do nothing
+        $subject = HomeEnvironmentChanger::create($oldHome);
+        $this->assertInstanceOf(__NAMESPACE__ . '\HomeEnvironmentChanger', $subject);
+        $retval = $subject->change();
+        $this->assertInstanceOf(HomeEnvironmentChanger::class, $retval);
+        $this->assertSame($subject, $retval);
+        $this->assertFalse(getenv('COMPOSER_HOME'));
+        $this->assertFalse(getenv('COMPOSER_CACHE'));
+
+        // change to a new setting should change it an create the cache entry
+        $subject = HomeEnvironmentChanger::create($newHome);
+        $subject->change();
+        $cache = getenv('COMPOSER_CACHE');
+        $this->assertNotFalse($cache);
+        $home = getenv('COMPOSER_HOME');
+        $this->assertNotFalse($home);
+        $this->assertNotSame($newHome . '/cache', $cache);
+        $this->assertNotSame(getenv('COMPOSER_HOME') . '/cache', $cache);
+        $this->assertSame(rtrim($homeDir, '/') . '/.composer/cache', $cache);
+    }
+
+    /**
+     * Test
+     *
+     * @test
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Path for composer home is not a directory or not writeable
+     * @return void
+     */
+    public function nonWriteableDirectoryThrowsExcetion()
+    {
+        HomeEnvironmentChanger::create("");
+    }
+}


### PR DESCRIPTION
MagentoComposerApplication changes the COMPOSER_HOME environment variable.

This has a lot of unwanted side-effects, one of them is the change of the
composer cache directory which then is broken.

The fix in this commit for the isolated cache detail is to preserve the
the cache from the previous location if not already set in the
COMPOSER_CACHE environment variable.

This is done by adding a helper class that is taking care of changing the
COMPOSER environment.
