### PR TITLE
Stabilize composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,14 +2,14 @@
   "name": "magento/composer",
   "description": "Magento composer library helps to instantiate Composer application and run composer commands.",
   "type": "library",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": [
     "OSL-3.0",
     "AFL-3.0"
   ],
   "require": {
     "php": "~5.5.0|~5.6.0|~7.0.0",
-    "composer/composer": "1.0.0-beta1",
+    "composer/composer": "^1.3.2",
     "symfony/console": "~2.3, !=2.7.0"
   },
   "require-dev": {


### PR DESCRIPTION
Composer now has stable releases and supports semantic versioning. This
commit stops magento/composer from blocking stable composer requirements
as it was previously by pinning it to a specific release (1.0.0-beta1).
- Ref: https://github.com/magento/magento2/issues/4359
