### PR TITLE
Remove "<2.7" constraint on symfony/console

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   "require": {
     "php": "~5.5.0|~5.6.0|~7.0.0",
     "composer/composer": "1.0.0-beta1",
-    "symfony/console": "~2.3 <2.7"
+    "symfony/console": "~2.3"
   },
   "require-dev": {
     "phpunit/phpunit": "4.1.0"


### PR DESCRIPTION
I guess this constraints was added before Symfony silenced its deprecation notices.
But now that it does, there should be no reason to exclude 2.7 & 2.8,
unless you've found a BC break blocker. In which case we'd be happy to know which one!

See also https://github.com/magento/magento2/pull/8151 on the magento2 repos.