### PR TITLE
Modifies parsing in InfoCommand.php to work with output containing \x08 characters written by ConsoleIO::doOverwrite (#8)

### DIFF
--- a/src/InfoCommand.php
+++ b/src/InfoCommand.php
@@ -72,7 +72,7 @@ class InfoCommand
             return false;
         }
 
-        $rawLines = explode("\n", str_replace("\r\n", "\n", $output));
+        $rawLines = explode("\n", str_replace("\r\n", "\n", preg_replace('/\x08+/', "\n", $output)));
         $result = [];
 
         foreach ($rawLines as $line) {


### PR DESCRIPTION
This pull request resolves an issue described in #8 