### PR TITLE
Update PHPUnit and tests and add PHP 7.2 to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,12 +8,12 @@
     "AFL-3.0"
   ],
   "require": {
-    "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0|~7.2.0",
+    "php": "~7.1.3|~7.2.0",
     "composer/composer": "~1.6.0",
     "symfony/console": "~4.0.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "~6.2.0"
+    "phpunit/phpunit": "~7.0.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -2,15 +2,15 @@
   "name": "magento/composer",
   "description": "Magento composer library helps to instantiate Composer application and run composer commands.",
   "type": "library",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "license": [
     "OSL-3.0",
     "AFL-3.0"
   ],
   "require": {
     "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0|~7.2.0",
-    "composer/composer": "1.4.1",
-    "symfony/console": "~2.3, !=2.7.0"
+    "composer/composer": "~1.6.0",
+    "symfony/console": "~4.0.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~6.2.0"

--- a/composer.json
+++ b/composer.json
@@ -8,12 +8,12 @@
     "AFL-3.0"
   ],
   "require": {
-    "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0",
+    "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0|~7.2.0",
     "composer/composer": "1.4.1",
     "symfony/console": "~2.3, !=2.7.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "4.1.0"
+    "phpunit/phpunit": "~6.2.0"
   },
   "autoload": {
     "psr-4": {

--- a/tests/Composer/ConsoleArrayInputFactoryTest.php
+++ b/tests/Composer/ConsoleArrayInputFactoryTest.php
@@ -21,6 +21,6 @@ class ConsoleArrayInputFactoryTest extends \PHPUnit\Framework\TestCase
 
     public function testCreate()
     {
-        $this->assertInstanceOf(Symfony\Component\Console\Input\ArrayInput::class, $this->factory->create([]));
+        $this->assertInstanceOf(\Symfony\Component\Console\Input\ArrayInput::class, $this->factory->create([]));
     }
 }

--- a/tests/Composer/ConsoleArrayInputFactoryTest.php
+++ b/tests/Composer/ConsoleArrayInputFactoryTest.php
@@ -6,7 +6,7 @@
 
 use Magento\Composer\ConsoleArrayInputFactory;
 
-class ConsoleArrayInputFactoryTest extends PHPUnit_Framework_TestCase
+class ConsoleArrayInputFactoryTest extends \PHPUnit\Framework\TestCase
 {
 
     /**
@@ -21,6 +21,6 @@ class ConsoleArrayInputFactoryTest extends PHPUnit_Framework_TestCase
 
     public function testCreate()
     {
-        $this->assertInstanceOf('\Symfony\Component\Console\Input\ArrayInput', $this->factory->create([]));
+        $this->assertInstanceOf(Symfony\Component\Console\Input\ArrayInput::class, $this->factory->create([]));
     }
 }

--- a/tests/Composer/InfoCommandTest.php
+++ b/tests/Composer/InfoCommandTest.php
@@ -33,7 +33,7 @@ php >=5.4.11
 
     protected function setUp()
     {
-        $this->application = $this->createMock(Magento\Composer\MagentoComposerApplication::class);
+        $this->application = $this->createMock(\Magento\Composer\MagentoComposerApplication::class);
 
         $this->infoCommand = new InfoCommand($this->application);
     }

--- a/tests/Composer/InfoCommandTest.php
+++ b/tests/Composer/InfoCommandTest.php
@@ -7,7 +7,7 @@
 use Magento\Composer\MagentoComposerApplication;
 use Magento\Composer\InfoCommand;
 
-class InfoCommandTest extends PHPUnit_Framework_TestCase
+class InfoCommandTest extends \PHPUnit\Framework\TestCase
 {
 
     private $installedOutput = 'name     : 3rdp/a
@@ -33,7 +33,7 @@ php >=5.4.11
 
     protected function setUp()
     {
-        $this->application = $this->getMock('Magento\Composer\MagentoComposerApplication', [], [], '', false, false);
+        $this->application = $this->createMock(Magento\Composer\MagentoComposerApplication::class);
 
         $this->infoCommand = new InfoCommand($this->application);
     }

--- a/tests/Composer/MagentoComposerApplicationTest.php
+++ b/tests/Composer/MagentoComposerApplicationTest.php
@@ -33,9 +33,9 @@ class MagentoComposerApplicationTest extends \PHPUnit\Framework\TestCase
 
     protected function setUp()
     {
-        $this->composerApplication = $this->createMock(Composer\Console\Application::class);
-        $this->inputFactory = $this->createMock(Magento\Composer\ConsoleArrayInputFactory::class);
-        $this->consoleOutput = $this->createMock(Symfony\Component\Console\Output\BufferedOutput::class);
+        $this->composerApplication = $this->createMock(\Composer\Console\Application::class);
+        $this->inputFactory = $this->createMock(\Magento\Composer\ConsoleArrayInputFactory::class);
+        $this->consoleOutput = $this->createMock(\Symfony\Component\Console\Output\BufferedOutput::class);
 
         $this->application = new MagentoComposerApplication(
             'path1',

--- a/tests/Composer/MagentoComposerApplicationTest.php
+++ b/tests/Composer/MagentoComposerApplicationTest.php
@@ -9,7 +9,7 @@ use Magento\Composer\MagentoComposerApplication;
 use Magento\Composer\ConsoleArrayInputFactory;
 use Symfony\Component\Console\Output\BufferedOutput;
 
-class MagentoComposerApplicationTest extends PHPUnit_Framework_TestCase
+class MagentoComposerApplicationTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var MagentoComposerApplication
@@ -33,20 +33,9 @@ class MagentoComposerApplicationTest extends PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->composerApplication = $this->getMock(
-            'Composer\Console\Application',
-            [
-                'resetComposer',
-                'create',
-                'run'
-            ],
-            [],
-            '',
-            false,
-            false
-        );
-        $this->inputFactory = $this->getMock('Magento\Composer\ConsoleArrayInputFactory', [], [], '', false);
-        $this->consoleOutput = $this->getMock('Symfony\Component\Console\Output\BufferedOutput', [], [], '', false);
+        $this->composerApplication = $this->createMock(Composer\Console\Application::class);
+        $this->inputFactory = $this->createMock(Magento\Composer\ConsoleArrayInputFactory::class);
+        $this->consoleOutput = $this->createMock(Symfony\Component\Console\Output\BufferedOutput::class);
 
         $this->application = new MagentoComposerApplication(
             'path1',

--- a/tests/Composer/RequireUpdateDryRunCommandTest.php
+++ b/tests/Composer/RequireUpdateDryRunCommandTest.php
@@ -64,8 +64,8 @@ Read <https://getcomposer.org/doc/articles/troubleshooting.md> for further commo
 
     protected function setUp()
     {
-        $this->application = $this->createMock(Magento\Composer\MagentoComposerApplication::class);
-        $this->infoCommand = $this->createMock(Magento\Composer\InfoCommand::class);
+        $this->application = $this->createMock(\Magento\Composer\MagentoComposerApplication::class);
+        $this->infoCommand = $this->createMock(\Magento\Composer\InfoCommand::class);
 
         $this->requireUpdateDryRunCommand = new RequireUpdateDryRunCommand(
             $this->application,

--- a/tests/Composer/RequireUpdateDryRunCommandTest.php
+++ b/tests/Composer/RequireUpdateDryRunCommandTest.php
@@ -8,7 +8,7 @@ use Magento\Composer\MagentoComposerApplication;
 use Magento\Composer\InfoCommand;
 use Magento\Composer\RequireUpdateDryRunCommand;
 
-class RequireUpdateDryRunCommandTest extends PHPUnit_Framework_TestCase
+class RequireUpdateDryRunCommandTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var MagentoComposerApplication|\PHPUnit_Framework_MockObject_MockObject
@@ -64,8 +64,8 @@ Read <https://getcomposer.org/doc/articles/troubleshooting.md> for further commo
 
     protected function setUp()
     {
-        $this->application = $this->getMock('Magento\Composer\MagentoComposerApplication', [], [], '', false, false);
-        $this->infoCommand = $this->getMock('Magento\Composer\InfoCommand', [], [], '', false, false);
+        $this->application = $this->createMock(Magento\Composer\MagentoComposerApplication::class);
+        $this->infoCommand = $this->createMock(Magento\Composer\InfoCommand::class);
 
         $this->requireUpdateDryRunCommand = new RequireUpdateDryRunCommand(
             $this->application,


### PR DESCRIPTION
* Update PHPUnit to version supported by PHP 7.2
* Fix unit tests for updated PHPUnit version

Fixes magento-engcom/php-7.2-support#2

Source: https://github.com/magento-engcom/magento-composer-php-7.2-support/pull/1