### PR TITLE
Add php7.3 to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "AFL-3.0"
   ],
   "require": {
-    "php": "~7.1.3|~7.2.0",
+    "php": "~7.1.3||~7.2.0||~7.3.0",
     "composer/composer": "^1.6",
     "symfony/console": "~4.0.0 || ~4.1.0"
   },


### PR DESCRIPTION
Tested on:
```sh
pmclain@756739b02c38:/var/www/html# php -v
PHP 7.3.0 (cli) (built: Dec 10 2018 13:50:58) ( NTS )
Copyright (c) 1997-2018 The PHP Group
Zend Engine v3.3.0-dev, Copyright (c) 1998-2018 Zend Technologies
    with the ionCube PHP Loader (enabled) + Intrusion Protection from ioncube24.com (unconfigured) v10.3.1, Copyright (c) 2002-2018, by ionCube Ltd.
    with Xdebug v2.7.0beta1, Copyright (c) 2002-2018, by Derick Rethans
```
```sh
pmclain@756739b02c38:/var/www/html# vendor/bin/phpunit
PHPUnit 7.0.3 by Sebastian Bergmann and contributors.

........                                                            8 / 8 (100%)

Time: 331 ms, Memory: 6.00MB

OK (8 tests, 18 assertions)
```