### PR TITLE
Update symfony/console dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   "require": {
     "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0|~7.2.0",
     "composer/composer": "1.4.1",
-    "symfony/console": "~2.3 || ~3.4, !=2.7.0"
+    "symfony/console": "~2.3 || ~3.4 || ~4.2, !=2.7.0"
   },
   "require-dev": {
     "phpunit/phpunit": "4.1.0"

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   "require": {
     "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0|~7.2.0",
     "composer/composer": "1.4.1",
-    "symfony/console": "~2.3, !=2.7.0"
+    "symfony/console": "~2.3 || ~3.4, !=2.7.0"
   },
   "require-dev": {
     "phpunit/phpunit": "4.1.0"


### PR DESCRIPTION
Current symfony/console version is outdated, new version constraint will allow newer version for Magento deployments that will allow it