### PR TITLE
Add Travis CI build service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: php
+php:
+ - 7.1
+ - 7.2
+ - 7.3
+install: composer install
+script: php vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,10 @@
     "psr-4": {
       "Magento\\Composer\\": "src"
     }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Magento\\Composer\\Tests\\": "tests"
+    }
   }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,16 +12,13 @@
 
     <testsuites>
         <testsuite name="Magento Composer Library Test">
-            <directory>./tests/</directory>
+            <directory suffix="Test.php">./tests/</directory>
         </testsuite>
     </testsuites>
 
     <filter>
         <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./tests</directory>
-            </exclude>
+            <directory>./src/</directory>
         </whitelist>
     </filter>
 </phpunit>

--- a/tests/Composer/ConsoleArrayInputFactoryTest.php
+++ b/tests/Composer/ConsoleArrayInputFactoryTest.php
@@ -4,9 +4,13 @@
  * See COPYING.txt for license details.
  */
 
-use Magento\Composer\ConsoleArrayInputFactory;
+namespace Magento\Composer\Tests;
 
-class ConsoleArrayInputFactoryTest extends \PHPUnit\Framework\TestCase
+use Magento\Composer\ConsoleArrayInputFactory;
+use Symfony\Component\Console\Input\ArrayInput;
+use PHPUnit\Framework\TestCase;
+
+class ConsoleArrayInputFactoryTest extends TestCase
 {
 
     /**
@@ -14,13 +18,13 @@ class ConsoleArrayInputFactoryTest extends \PHPUnit\Framework\TestCase
      */
     protected $factory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->factory = new ConsoleArrayInputFactory();
     }
 
     public function testCreate()
     {
-        $this->assertInstanceOf(\Symfony\Component\Console\Input\ArrayInput::class, $this->factory->create([]));
+        $this->assertInstanceOf(ArrayInput::class, $this->factory->create([]));
     }
 }

--- a/tests/Composer/InfoCommandTest.php
+++ b/tests/Composer/InfoCommandTest.php
@@ -4,10 +4,13 @@
  * See COPYING.txt for license details.
  */
 
+namespace Magento\Composer\Tests;
+
 use Magento\Composer\MagentoComposerApplication;
 use Magento\Composer\InfoCommand;
+use PHPUnit\Framework\TestCase;
 
-class InfoCommandTest extends \PHPUnit\Framework\TestCase
+class InfoCommandTest extends TestCase
 {
 
     private $installedOutput = 'name     : 3rdp/a

--- a/tests/Composer/MagentoComposerApplicationTest.php
+++ b/tests/Composer/MagentoComposerApplicationTest.php
@@ -4,12 +4,15 @@
  * See COPYING.txt for license details.
  */
 
+namespace Magento\Composer\Tests;
+
 use Composer\Console\Application;
 use Magento\Composer\MagentoComposerApplication;
 use Magento\Composer\ConsoleArrayInputFactory;
 use Symfony\Component\Console\Output\BufferedOutput;
+use PHPUnit\Framework\TestCase;
 
-class MagentoComposerApplicationTest extends \PHPUnit\Framework\TestCase
+class MagentoComposerApplicationTest extends TestCase
 {
     /**
      * @var MagentoComposerApplication

--- a/tests/Composer/RequireUpdateDryRunCommandTest.php
+++ b/tests/Composer/RequireUpdateDryRunCommandTest.php
@@ -4,11 +4,14 @@
  * See COPYING.txt for license details.
  */
 
+namespace Magento\Composer\Tests;
+
 use Magento\Composer\MagentoComposerApplication;
 use Magento\Composer\InfoCommand;
 use Magento\Composer\RequireUpdateDryRunCommand;
+use PHPUnit\Framework\TestCase;
 
-class RequireUpdateDryRunCommandTest extends \PHPUnit\Framework\TestCase
+class RequireUpdateDryRunCommandTest extends TestCase
 {
     /**
      * @var MagentoComposerApplication|\PHPUnit_Framework_MockObject_MockObject


### PR DESCRIPTION
# Changed log
- Integrating Travis CI build.
The Travis CI build log is available [here](https://travis-ci.org/open-source-contributions/composer/builds/603585685) and it runs on forked repository.
- To be consistency, let `PHPUnit\Framework\TestCase` namespace defined on every head of PHP file.