### PR TITLE
#33339: declare PHP 8 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "AFL-3.0"
   ],
   "require": {
-    "php": "~7.3.0||~7.4.0",
+    "php": "~7.3.0||~7.4.0||~8.0.0",
     "composer/composer": "^1.9 || ^2.0",
     "symfony/console": "~4.4.0"
   },


### PR DESCRIPTION
Declared PHP 8 compatibility

Fixes magento/magento2#33339

Reopened: https://github.com/magento/composer/pull/29